### PR TITLE
Refactor scope analysis tests and update token storage

### DIFF
--- a/Blazorade.Id.Tests/ScopeAnalyzerTests.cs
+++ b/Blazorade.Id.Tests/ScopeAnalyzerTests.cs
@@ -8,14 +8,14 @@ using System.Threading.Tasks;
 namespace Blazorade.Id.Tests
 {
     [TestClass]
-    public class ScopeSorterTests
+    public class ScopeAnalyzerTests
     {
 
         [TestMethod]
-        public async Task SortScopes01()
+        public async Task AnalyzeScopes01()
         {
-            var sorter = new ScopeAnalyzer();
-            var analyzed = await sorter.AnalyzeScopesAsync(new[] 
+            var analyzer = new ScopeAnalyzer();
+            var analyzed = await analyzer.AnalyzeScopesAsync(new[] 
             { 
                 "openid", 
                 "profile", 
@@ -36,12 +36,11 @@ namespace Blazorade.Id.Tests
         }
 
         [TestMethod]
-        public async Task SortScopes02()
+        public async Task AnalyzeScopes02()
         {
             string[] source = ["api://foo-bar/stuff.do", "https://api.mycompany.com/read"];
-            var sorter = new ScopeAnalyzer();
-            var analyzed = await sorter.AnalyzeScopesAsync(source);
-
+            var analyzer = new ScopeAnalyzer();
+            var analyzed = await analyzer.AnalyzeScopesAsync(source);
             Assert.HasCount(2, analyzed);
             foreach(var key in analyzed.Keys)
             {

--- a/Blazorade.Id.Tests/Services/ServiceRegistrations.cs
+++ b/Blazorade.Id.Tests/Services/ServiceRegistrations.cs
@@ -1,4 +1,5 @@
 ﻿using Blazorade.Id.Configuration;
+using Blazorade.Id.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -19,6 +20,12 @@ namespace Blazorade.Id.Tests.Services
                 .AddAuthorizationCodeProvider<TestCodeProvider>()
                 .AddRedirectUriProvider<TestRedirectUriProvider>()
                 .AddTokenRefresher<TestTokenRefresher>()
+                .AddRefreshTokenStore<InMemoryRefreshTokenStore>()
+
+                .AddAuthority((sp, options) =>
+                {
+                    options.Scope = "openid profile email User.Read urn:blazorade:id/user_impersonation";
+                })
                 .Services
 
                 .BuildServiceProvider();

--- a/Blazorade.Id.Tests/Services/TestTokenRefresher.cs
+++ b/Blazorade.Id.Tests/Services/TestTokenRefresher.cs
@@ -37,7 +37,7 @@ namespace Blazorade.Id.Tests.Services
             {
                 var claims = new List<Claim>()
                 {
-                    new Claim("scp", string.Join(' ', item.Value))
+                    new Claim("scp", string.Join(' ', from x in item.Value select x.Value))
                 };
 
                 if(this.Expiration.HasValue)

--- a/Blazorade.Id.Tests/TokenServiceTests.cs
+++ b/Blazorade.Id.Tests/TokenServiceTests.cs
@@ -101,10 +101,5 @@ namespace Blazorade.Id.Tests
             Assert.Contains("openid", scopes);
         }
 
-        [TestMethod]
-        public async Task GetAccessTokens004()
-        {
-
-        }
     }
 }

--- a/Blazorade.Id.Tests/TokenServiceTests.cs
+++ b/Blazorade.Id.Tests/TokenServiceTests.cs
@@ -2,6 +2,7 @@
 using Blazorade.Id.Model;
 using Blazorade.Id.Services;
 using Blazorade.Id.Tests.Services;
+using Microsoft.Extensions.Options;
 using Microsoft.Testing.Platform.Services;
 using System;
 using System.Collections.Generic;
@@ -27,6 +28,7 @@ namespace Blazorade.Id.Tests
         private TestCodeProvider CodeProvider = null!;
         private ITokenStore TokenStore = null!;
         private IRefreshTokenStore RefreshTokenStore = null!;
+        private AuthorityOptions AuthOptions = null!;
 
         [TestInitialize]
         public void TestInitialize()
@@ -38,7 +40,9 @@ namespace Blazorade.Id.Tests
             this.CodeProvider = this.Provider.GetAuthCodeProvider();
             this.TokenStore = this.Provider.GetRequiredService<ITokenStore>();
             this.RefreshTokenStore = this.Provider.GetRequiredService<IRefreshTokenStore>();
+            this.AuthOptions = this.Provider.GetRequiredService<IOptions<AuthorityOptions>>().Value;
         }
+
 
 
         [TestMethod]
@@ -46,7 +50,7 @@ namespace Blazorade.Id.Tests
         {
             await this.RefreshTokenStore.SetRefreshTokenAsync("refresh-token");
             this.TokenRefresher.Expiration = DateTimeOffset.UtcNow.AddHours(1);
-            var ats = await this.TokenService.GetAccessTokensAsync(new GetTokenOptions { Scopes = new[] { "openid", "profile", "email", "urn:blazorade:id/user_impersonation" } });
+            var ats = await this.TokenService.GetAccessTokensAsync(new GetTokenOptions { Scopes = new[] { "openid", "profile", "email", "User.Read", "urn:blazorade:id/user_impersonation" } });
             Assert.IsNotNull(ats);
             Assert.HasCount(2, ats);
 
@@ -59,11 +63,11 @@ namespace Blazorade.Id.Tests
         public async Task GetAccessTokens002()
         {
             this.TokenRefresher.Expiration = DateTimeOffset.UtcNow.AddHours(1);
-            this.CodeProcessor.ScopesToProcess = AuthorityOptions.DefaultScope.Split(' ');
+            this.CodeProcessor.ScopesToProcess = this.AuthOptions.Scope?.Split(' ') ?? [];
 
             var ats = await this.TokenService.GetAccessTokensAsync();
             Assert.IsNotNull(ats);
-            Assert.HasCount(1, ats);
+            Assert.HasCount(2, ats);
 
             var token = ats.GetTokenByScope(AuthorityOptions.DefaultScope);
             Assert.IsNotNull(token);
@@ -71,6 +75,7 @@ namespace Blazorade.Id.Tests
             Assert.Contains("openid", scopes);
             Assert.Contains("profile", scopes);
             Assert.Contains("email", scopes);
+            Assert.Contains("User.Read", scopes);
         }
 
         [TestMethod]

--- a/SimpleServerApp/Program.cs
+++ b/SimpleServerApp/Program.cs
@@ -20,7 +20,8 @@ builder.Services
             options.AuthorizationWindowWidth = 1280;
             options.AuthorizationWindowHeight = 768;
         })
-
+        .AddTokenStore<BrowserSessionStorageTokenStore>()
+        .AddRefreshTokenStore<BrowserSessionStorageRefreshTokenStore>()
     ;
 
 


### PR DESCRIPTION
Replaced ScopeSorterTests with ScopeAnalyzerTests to verify scope grouping by authority. Updated service registrations to use InMemoryRefreshTokenStore and set default scopes. Fixed "scp" claim generation in TestTokenRefresher. TokenServiceTests now use AuthorityOptions and expect multiple access tokens. Program.cs now registers browser session storage for tokens.